### PR TITLE
Do not print connection warning message for ping and pong messages

### DIFF
--- a/stp_core/test/helper.py
+++ b/stp_core/test/helper.py
@@ -75,6 +75,7 @@ def prepStacks(looper, *stacks, connect=True, useKeys=True):
         looper.add(motor)
     if connect:
         connectStacks(stacks, useKeys)
+        looper.runFor(1)
 
 
 def connectStacks(stacks, useKeys=True):

--- a/stp_zmq/zstack.py
+++ b/stp_zmq/zstack.py
@@ -184,6 +184,7 @@ class ZStack(NetworkInterface):
     sigLen = 64
     pingMessage = 'pi'
     pongMessage = 'po'
+    healthMessages = {pingMessage.encode(), pongMessage.encode()}
 
     # TODO: This is not implemented, implement this
     messageTimeout = 3
@@ -805,7 +806,7 @@ class ZStack(NetworkInterface):
             socket.send(msg, flags=zmq.NOBLOCK)
             logger.debug('{} transmitting message {} to {}'
                         .format(self, msg, uid))
-            if not remote.isConnected: # and not remote.firstConnect:
+            if not remote.isConnected and msg not in self.healthMessages:
                 logger.warning('Remote {} is not connected - '
                                'message will not be sent immediately.'
                                'If this problem does not resolve itself - '


### PR DESCRIPTION
Ping and pong are service messages that can be sent between not fully connected stacks, so there is no need to print warning about missing connection for them